### PR TITLE
semantic improvements: reward

### DIFF
--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -33,7 +33,7 @@ contract Parameterizer {
     bool resolved;          // indication of if challenge is resolved
     uint stake;             // number of tokens at risk for either party during challenge
     uint winningTokens;     // (remaining) amount of tokens used for voting by the winning side
-    mapping(address => bool) tokenClaims;
+    mapping(address => bool) voterCanClaimReward;
   }
 
   // ------
@@ -198,9 +198,9 @@ contract Parameterizer {
   @param _challengeID the challenge ID to claim tokens for
   @param _salt the salt used to vote in the challenge being withdrawn for
   */
-  function claimReward(uint _challengeID, uint _salt) public {
+  function claimVoterReward(uint _challengeID, uint _salt) public {
     // ensure voter has not already claimed tokens and challenge results have been processed
-    require(challenges[_challengeID].tokenClaims[msg.sender] == false);
+    require(challenges[_challengeID].voterCanClaimReward[msg.sender] == false);
     require(challenges[_challengeID].resolved == true);
 
     uint voterTokens = voting.getNumPassingTokens(msg.sender, _challengeID, _salt);
@@ -214,7 +214,7 @@ contract Parameterizer {
     require(token.transfer(msg.sender, reward));
     
     // ensures a voter cannot claim tokens again
-    challenges[_challengeID].tokenClaims[msg.sender] = true;
+    challenges[_challengeID].voterCanClaimReward[msg.sender] = true;
   }
 
   // --------

--- a/migrations/2_token.js
+++ b/migrations/2_token.js
@@ -16,6 +16,7 @@ module.exports = (deployer, network) => {
       0,
       tokenHolder.amount.length - parseInt(config.token.decimals, 10),
     );
+    // eslint-disable-next-line no-console
     console.log(`Allocating ${displayAmt} ${config.token.symbol} tokens to ` +
     `${tokenHolder.address}.`);
 
@@ -31,6 +32,7 @@ module.exports = (deployer, network) => {
     )
       .then(async () => giveTokensTo(config.token.tokenHolders));
   } else {
+    // eslint-disable-next-line no-console
     console.log('skipping optional token deploy and using the token at address ' +
       `${config.token.address} on network ${network}.`);
   }

--- a/test/parameterizer/challengeWinnerReward.js
+++ b/test/parameterizer/challengeWinnerReward.js
@@ -2,7 +2,7 @@
 /* global contract */
 
 contract('Parameterizer', () => {
-  describe('Function: determineReward', () => {
+  describe('Function: challengeWinnerReward', () => {
     it('should return the correct number of tokens to be granted to the winning entity in a challenge.');
   });
 });

--- a/test/parameterizer/claimVoterReward.js
+++ b/test/parameterizer/claimVoterReward.js
@@ -13,7 +13,7 @@ const paramConfig = config.paramDefaults;
 const bigTen = number => new BN(number.toString(10), 10);
 
 contract('Parameterizer', (accounts) => {
-  describe('Function: claimReward', () => {
+  describe('Function: claimVoterReward', () => {
     const [proposer, challenger, voterAlice, voterBob] = accounts;
 
     it('should give the correct number of tokens to a voter on the winning side.', async () => {
@@ -40,7 +40,7 @@ contract('Parameterizer', (accounts) => {
 
       await parameterizer.processProposal(propID);
 
-      await utils.as(voterAlice, parameterizer.claimReward, challengeID, '420');
+      await utils.as(voterAlice, parameterizer.claimVoterReward, challengeID, '420');
       await utils.as(voterAlice, voting.withdrawVotingRights, '10');
 
       const voterAliceFinalBalance = await token.balanceOf.call(voterAlice);
@@ -87,14 +87,14 @@ contract('Parameterizer', (accounts) => {
           voterAlice,
           challengeID, '420',
         );
-        await utils.as(voterAlice, parameterizer.claimReward, challengeID, '420');
+        await utils.as(voterAlice, parameterizer.claimVoterReward, challengeID, '420');
         await utils.as(voterAlice, voting.withdrawVotingRights, '10');
 
         const voterBobReward = await parameterizer.voterReward.call(
           voterBob,
           challengeID, '420',
         );
-        await utils.as(voterBob, parameterizer.claimReward, challengeID, '420');
+        await utils.as(voterBob, parameterizer.claimVoterReward, challengeID, '420');
         await utils.as(voterBob, voting.withdrawVotingRights, '20');
 
         // TODO: do better than approximately.
@@ -132,8 +132,8 @@ contract('Parameterizer', (accounts) => {
       await utils.increaseTime(paramConfig.pRevealStageLength + 1);
 
       try {
-        await utils.as(voterAlice, parameterizer.claimReward, challengeID, '420');
-        assert(false, 'should not have been able to claimReward for unresolved challenge');
+        await utils.as(voterAlice, parameterizer.claimVoterReward, challengeID, '420');
+        assert(false, 'should not have been able to claimVoterReward for unresolved challenge');
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
       }

--- a/test/registry/challengeWinnerReward.js
+++ b/test/registry/challengeWinnerReward.js
@@ -2,7 +2,7 @@
 /* global contract */
 
 contract('Registry', () => {
-  describe('Function: determineReward', () => {
+  describe('Function: challengeWinnerReward', () => {
     it('should return the correct value of reward for a given challengeID');
     it('should throw errors if it hasnt been resolved or its already ended');
   });

--- a/test/registry/claimVoterReward.js
+++ b/test/registry/claimVoterReward.js
@@ -14,7 +14,7 @@ const utils = require('../utils.js');
 const bigTen = number => new BN(number.toString(10), 10);
 
 contract('Registry', (accounts) => {
-  describe('Function: claimReward', () => {
+  describe('Function: claimVoterReward', () => {
     const [applicant, challenger, voterAlice] = accounts;
     const minDeposit = bigTen(paramConfig.minDeposit);
 
@@ -44,7 +44,7 @@ contract('Registry', (accounts) => {
 
       // Alice claims reward
       const aliceVoterReward = await registry.voterReward(voterAlice, pollID, '420');
-      await utils.as(voterAlice, registry.claimReward, pollID, '420');
+      await utils.as(voterAlice, registry.claimVoterReward, pollID, '420');
 
       // Alice withdraws her voting rights
       await utils.as(voterAlice, voting.withdrawVotingRights, '500');
@@ -65,8 +65,8 @@ contract('Registry', (accounts) => {
 
       try {
         const nonPollID = '666';
-        await utils.as(voterAlice, registry.claimReward, nonPollID, '420');
-        assert(false, 'should not have been able to claimReward for non-existant challengeID');
+        await utils.as(voterAlice, registry.claimVoterReward, nonPollID, '420');
+        assert(false, 'should not have been able to claimVoterReward for non-existant challengeID');
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
       }
@@ -109,8 +109,8 @@ contract('Registry', (accounts) => {
       await utils.as(applicant, registry.updateStatus, listing);
 
       try {
-        await utils.as(voterAlice, registry.claimReward, pollID, '421');
-        assert(false, 'should not have been able to claimReward with the wrong salt');
+        await utils.as(voterAlice, registry.claimVoterReward, pollID, '421');
+        assert(false, 'should not have been able to claimVoterReward with the wrong salt');
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
       }
@@ -142,11 +142,11 @@ contract('Registry', (accounts) => {
       await utils.as(applicant, registry.updateStatus, listing);
 
       // Claim reward
-      await utils.as(voterAlice, registry.claimReward, pollID, '420');
+      await utils.as(voterAlice, registry.claimVoterReward, pollID, '420');
 
       try {
-        await utils.as(voterAlice, registry.claimReward, pollID, '420');
-        assert(false, 'should not have been able to call claimReward twice');
+        await utils.as(voterAlice, registry.claimVoterReward, pollID, '420');
+        assert(false, 'should not have been able to call claimVoterReward twice');
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
       }
@@ -190,8 +190,8 @@ contract('Registry', (accounts) => {
       await utils.increaseTime(paramConfig.revealStageLength + 1);
 
       try {
-        await utils.as(voterAlice, registry.claimReward, pollID, '420');
-        assert(false, 'should not have been able to claimReward for unresolved challenge');
+        await utils.as(voterAlice, registry.claimVoterReward, pollID, '420');
+        assert(false, 'should not have been able to claimVoterReward for unresolved challenge');
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
       }

--- a/test/registry/voterCanClaimReward.js
+++ b/test/registry/voterCanClaimReward.js
@@ -13,7 +13,7 @@ const utils = require('../utils.js');
 const bigTen = number => new BN(number.toString(10), 10);
 
 contract('Registry', (accounts) => {
-  describe('Function: tokenClaims', () => {
+  describe('Function: voterCanClaimReward', () => {
     const minDeposit = bigTen(paramConfig.minDeposit);
     const [applicant, challenger, voter] = accounts;
 
@@ -34,13 +34,13 @@ contract('Registry', (accounts) => {
 
       await utils.as(challenger, registry.updateStatus, listing);
 
-      const initialHasClaimed = await registry.tokenClaims.call(pollID, voter);
+      const initialHasClaimed = await registry.voterCanClaimReward.call(pollID, voter);
       assert.strictEqual(initialHasClaimed, false, 'The voter is purported to have claimed ' +
         'their reward, when in fact they have not');
 
-      await utils.as(voter, registry.claimReward, pollID, '420');
+      await utils.as(voter, registry.claimVoterReward, pollID, '420');
 
-      const finalHasClaimed = await registry.tokenClaims.call(pollID, voter);
+      const finalHasClaimed = await registry.voterCanClaimReward.call(pollID, voter);
       assert.strictEqual(finalHasClaimed, true, 'The voter is purported to not have claimed ' +
         'their reward, when in fact they have');
     });


### PR DESCRIPTION
this addresses #9 

the following functions have been renamed accordingly. tests are passing.

`determineReward` -> `challengeWinnerReward`

`claimReward` -> `claimVoterReward`

`tokenClaims` -> `voterCanClaimReward`