### PR TITLE
Remove `data` parameter from challenge

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -11,7 +11,7 @@ contract Registry {
     // ------
 
     event _Application(bytes32 listingHash, uint deposit, string data);
-    event _Challenge(bytes32 listingHash, uint deposit, uint pollID, string data);
+    event _Challenge(bytes32 listingHash, uint deposit, uint pollID);
     event _Deposit(bytes32 listingHash, uint added, uint newTotal);
     event _Withdrawal(bytes32 listingHash, uint withdrew, uint newTotal);
     event _NewListingWhitelisted(bytes32 listingHash);
@@ -70,7 +70,7 @@ contract Registry {
     @dev Contructor         Sets the addresses for token, voting, and parameterizer
     @param _tokenAddr       Address of the TCR's intrinsic ERC20 token
     @param _plcrAddr        Address of a PLCR voting contract for the provided token
-    @param _paramsAddr      Address of a Parameterizer contract 
+    @param _paramsAddr      Address of a Parameterizer contract
     */
     function Registry(
         address _tokenAddr,
@@ -94,7 +94,7 @@ contract Registry {
         parameterizer = Parameterizer(_paramsAddr);
         name = _name;
     }
-    
+
     // --------------------
     // PUBLISHER INTERFACE:
     // --------------------
@@ -189,9 +189,8 @@ contract Registry {
                         already in the whitelist. Tokens are taken from the challenger and the
                         applicant's deposits are locked.
     @param _listingHash The listingHash being challenged, whether listed or in application
-    @param _data        Extra data relevant to the challenge. Think IPFS hashes.
     */
-    function challenge(bytes32 _listingHash, string _data) external returns (uint challengeID) {
+    function challenge(bytes32 _listingHash) external returns (uint challengeID) {
         Listing storage listing = listings[_listingHash];
         uint deposit = parameterizer.get("minDeposit");
 
@@ -230,7 +229,7 @@ contract Registry {
         // Locks tokens for listingHash during challenge
         listing.unstakedDeposit -= deposit;
 
-        _Challenge(_listingHash, deposit, pollID, _data);
+        _Challenge(_listingHash, deposit, pollID);
         return pollID;
     }
 

--- a/test/registry/challenge.js
+++ b/test/registry/challenge.js
@@ -148,7 +148,7 @@ contract('Registry', (accounts) => {
       await parameterizer.processProposal(propID);
 
       const challengerStartingBal = await token.balanceOf.call(challenger);
-      utils.as(challenger, registry.challenge, listing, '');
+      utils.as(challenger, registry.challenge, listing);
       const challengerFinalBal = await token.balanceOf.call(challenger);
 
       assert(

--- a/test/registry/deposit.js
+++ b/test/registry/deposit.js
@@ -57,7 +57,7 @@ contract('Registry', (accounts) => {
       const originalDeposit = await utils.getUnstakedDeposit(listing);
 
       // challenge, then increase deposit
-      await utils.as(challenger, registry.challenge, listing, '');
+      await utils.as(challenger, registry.challenge, listing);
       await utils.as(applicant, registry.deposit, listing, incAmount);
 
       const afterIncDeposit = await utils.getUnstakedDeposit(listing);

--- a/test/registry/exit.js
+++ b/test/registry/exit.js
@@ -54,7 +54,7 @@ contract('Registry', (accounts) => {
       const isWhitelisted = await registry.isWhitelisted.call(listing);
       assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
 
-      await registry.challenge(listing, '', { from: challenger });
+      await registry.challenge(listing, { from: challenger });
       try {
         await registry.exit(listing, { from: applicant });
         assert(false, 'exit succeeded when it should have failed');

--- a/test/registry/updateStatus.js
+++ b/test/registry/updateStatus.js
@@ -45,7 +45,7 @@ contract('Registry', (accounts) => {
       const listing = utils.getListingHash('dontwhitelist.io');
 
       await utils.as(applicant, registry.apply, listing, minDeposit, '');
-      await utils.as(challenger, registry.challenge, listing, '');
+      await utils.as(challenger, registry.challenge, listing);
 
       try {
         await registry.updateStatus(listing);
@@ -60,7 +60,7 @@ contract('Registry', (accounts) => {
       const listing = utils.getListingHash('dontwhitelist.net');
 
       await utils.as(applicant, registry.apply, listing, minDeposit, '');
-      await utils.as(challenger, registry.challenge, listing, '');
+      await utils.as(challenger, registry.challenge, listing);
 
       const plcrComplete = paramConfig.revealStageLength + paramConfig.commitStageLength + 1;
       await utils.increaseTime(plcrComplete);

--- a/test/registry/userStories.js
+++ b/test/registry/userStories.js
@@ -21,7 +21,7 @@ contract('Registry', (accounts) => {
       const registry = await Registry.deployed();
       const listing = utils.getListingHash('failChallenge.net'); // listing to apply with
       await registry.apply(listing, paramConfig.minDeposit, '', { from: applicant });
-      await registry.challenge(listing, '', { from: challenger });
+      await registry.challenge(listing, { from: challenger });
 
       await utils.increaseTime(paramConfig.revealStageLength + paramConfig.commitStageLength + 1);
       await registry.updateStatus(listing);

--- a/test/registry/withdraw.js
+++ b/test/registry/withdraw.js
@@ -81,7 +81,7 @@ contract('Registry', (accounts) => {
 
       // Whitelist, then challenge
       await utils.addToWhitelist(listing, minDeposit, applicant);
-      await utils.as(challenger, registry.challenge, listing, '');
+      await utils.as(challenger, registry.challenge, listing);
 
       try {
         // Attempt to withdraw; should fail

--- a/test/utils.js
+++ b/test/utils.js
@@ -103,7 +103,7 @@ const utils = {
 
   challengeAndGetPollID: async (domain, actor) => {
     const registry = await Registry.deployed();
-    const receipt = await utils.as(actor, registry.challenge, domain, '');
+    const receipt = await utils.as(actor, registry.challenge, domain);
     return receipt.logs[0].args.pollID;
   },
 


### PR DESCRIPTION
I think the parameter `data` isn't much of use because:
- the method `challange` in fact is about to change the state of the contract regardless of the parameter `_data` which doesn't have validation.
- in the `_Challenge` behavior, the parameter `data` seems to be usless due to the lack of validation, thus you can't be sure of the data type coming. On the client side you can't 'react' on the 'invalid' parameter properly. So it finally doesn't make any sense to check it somehow.
- The problem is, having the `data` parameter in fact only increases the gas consumption of the contract.

Maybe we need to think to deprecate the `data` parameter.