### PR TITLE
Add a "name" variable to Registry storage

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -13,6 +13,7 @@
     "voteQuorum": 50,
     "pVoteQuorum": 50
 	},
+  "name": "The TestChain Registry",
   "token": {
     "address": "0x337cDDa6D41A327c5ad456166CCB781a9722AFf9",
     "deployToken": true,

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -53,7 +53,7 @@ contract Registry {
     EIP20Interface public token;
     PLCRVoting public voting;
     Parameterizer public parameterizer;
-    string public version = '1';
+    string public name;
 
     // ------------
     // CONSTRUCTOR:
@@ -68,11 +68,13 @@ contract Registry {
     function Registry(
         address _tokenAddr,
         address _plcrAddr,
-        address _paramsAddr
+        address _paramsAddr,
+        string _name
     ) public {
         token = EIP20Interface(_tokenAddr);
         voting = PLCRVoting(_plcrAddr);
         parameterizer = Parameterizer(_paramsAddr);
+        name = _name;
     }
 
     // --------------------

--- a/migrations/6_deploy_registry.js
+++ b/migrations/6_deploy_registry.js
@@ -35,6 +35,7 @@ module.exports = (deployer, network, accounts) => {
       tokenAddress,
       PLCRVoting.address,
       Parameterizer.address,
+      config.name,
     );
   })
     .then(async () => {

--- a/test/registry/Registry.js
+++ b/test/registry/Registry.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha */
+/* global assert contract artifacts */
+
+const Registry = artifacts.require('Registry.sol');
+const Token = artifacts.require('EIP20.sol');
+const Parameterizer = artifacts.require('Parameterizer.sol');
+const PLCRVoting = artifacts.require('PLCRVoting.sol');
+
+const fs = require('fs');
+
+const config = JSON.parse(fs.readFileSync('./conf/config.json'));
+
+contract('Registry', () => {
+  describe('Function: Registry (constructor)', () => {
+    it('should instantiate storage variables with the values in the config file', async () => {
+      const registry = await Registry.deployed();
+      const token = await Token.deployed();
+      const parameterizer = await Parameterizer.deployed();
+      const plcrVoting = await PLCRVoting.deployed();
+
+      assert.strictEqual((await registry.token.call()), token.address, 'The token storage ' +
+        'variable is improperly initialized');
+      assert.strictEqual(
+        (await registry.parameterizer.call()), parameterizer.address,
+        'The parameterizer storage variable is improperly initialized',
+      );
+      assert.strictEqual(
+        (await registry.voting.call()), plcrVoting.address,
+        'The voting storage variable is improperly initialized',
+      );
+      assert.strictEqual(
+        (await registry.name.call()), config.name,
+        'The name storage variable is improperly initialized',
+      );
+    });
+  });
+});


### PR DESCRIPTION
It will be useful for registries to have names the same way that tokens have names, for example "The AdChain Registry" or "The Cool Registry".

* Add a "name" property to the config file
* Update the Registry migration to pass the name to the constructor
* Add a name variable to registry storage, and a _name parameter to the registry constructor. Set the name parameter using the _name argument in the constructor.
* Add a test asserting that Registry storage values are set correctly at deploy-time.