### PR TITLE
Add Solidity syntax highlighting on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Some people like colors.

* Add a .gitattributes file asserting .sol files should be rendered as Solidity code