### PR TITLE
Fix coverage reporting

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,7 @@
 module.exports = {
-  port: 8555,
   // use the local version of truffle
-  testCommand: '../node_modules/.bin/truffle test --network coverage -p 7545'
+  testCommand: '../node_modules/.bin/truffle test --network coverage',
+  // start blockchain on the same port specified in truffle.js
+  // use the default delicious Ganache mnemonic
+  testrpcOptions: '-p 7545 -m "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"'
 };


### PR DESCRIPTION
Tests were failing when running coverage because none of the addresses
in the testrpc run by the coverage had any tokens allocated to them.
This is because the config file uses addresses derived from a specific
mnemonic, and the coverage testrpc was using a random one each time.

* Specify a mnemonic to make sure coverage generates the same addresses
  as those specified in the config file