### PR TITLE
Add msgSender arg to relevent event emissions

### DIFF
--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -10,8 +10,8 @@ contract Parameterizer {
   // EVENTS
   // ------
 
-  event _ReparameterizationProposal(string name, uint value, bytes32 propID, uint deposit, uint appEndDate, address proposer);
-  event _NewChallenge(bytes32 indexed propID, uint challengeID, uint commitEndDate, uint revealEndDate, address challenger);
+  event _ReparameterizationProposal(string name, uint value, bytes32 propID, uint deposit, uint appEndDate, address indexed proposer);
+  event _NewChallenge(bytes32 indexed propID, uint challengeID, uint commitEndDate, uint revealEndDate, address indexed challenger);
   event _ProposalAccepted(bytes32 indexed propID, string name, uint value);
   event _ProposalExpired(bytes32 indexed propID);
   event _ChallengeSucceeded(bytes32 indexed propID, uint indexed challengeID, uint rewardPool, uint totalTokens);

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -10,8 +10,8 @@ contract Parameterizer {
   // EVENTS
   // ------
 
-  event _ReparameterizationProposal(string name, uint value, bytes32 propID, uint deposit, uint appEndDate, address msgSender);
-  event _NewChallenge(bytes32 indexed propID, uint challengeID, uint commitEndDate, uint revealEndDate, address msgSender);
+  event _ReparameterizationProposal(string name, uint value, bytes32 propID, uint deposit, uint appEndDate, address proposer);
+  event _NewChallenge(bytes32 indexed propID, uint challengeID, uint commitEndDate, uint revealEndDate, address challenger);
   event _ProposalAccepted(bytes32 indexed propID, string name, uint value);
   event _ProposalExpired(bytes32 indexed propID);
   event _ChallengeSucceeded(bytes32 indexed propID, uint indexed challengeID, uint rewardPool, uint totalTokens);

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -10,8 +10,8 @@ contract Parameterizer {
   // EVENTS
   // ------
 
-  event _ReparameterizationProposal(string name, uint value, bytes32 propID, uint deposit, uint appEndDate);
-  event _NewChallenge(bytes32 indexed propID, uint challengeID, uint commitEndDate, uint revealEndDate);
+  event _ReparameterizationProposal(string name, uint value, bytes32 propID, uint deposit, uint appEndDate, address msgSender);
+  event _NewChallenge(bytes32 indexed propID, uint challengeID, uint commitEndDate, uint revealEndDate, address msgSender);
   event _ProposalAccepted(bytes32 indexed propID, string name, uint value);
   event _ProposalExpired(bytes32 indexed propID);
   event _ChallengeSucceeded(bytes32 indexed propID, uint indexed challengeID, uint rewardPool, uint totalTokens);
@@ -152,7 +152,7 @@ contract Parameterizer {
 
     require(token.transferFrom(msg.sender, this, deposit)); // escrow tokens (deposit amt)
 
-    _ReparameterizationProposal(_name, _value, propID, deposit, proposals[propID].appExpiry);
+    _ReparameterizationProposal(_name, _value, propID, deposit, proposals[propID].appExpiry, msg.sender);
     return propID;
   }
 
@@ -188,7 +188,7 @@ contract Parameterizer {
 
     var (commitEndDate, revealEndDate,) = voting.pollMap(pollID);
 
-    _NewChallenge(_propID, pollID, commitEndDate, revealEndDate);
+    _NewChallenge(_propID, pollID, commitEndDate, revealEndDate, msg.sender);
     return pollID;
   }
 

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -11,8 +11,8 @@ contract Registry {
     // EVENTS
     // ------
 
-    event _Application(bytes32 indexed listingHash, uint deposit, uint appEndDate, string data, address applicant);
-    event _Challenge(bytes32 indexed listingHash, uint challengeID, string data, uint commitEndDate, uint revealEndDate, address challenger);
+    event _Application(bytes32 indexed listingHash, uint deposit, uint appEndDate, string data, address indexed applicant);
+    event _Challenge(bytes32 indexed listingHash, uint challengeID, string data, uint commitEndDate, uint revealEndDate, address indexed challenger);
     event _Deposit(bytes32 indexed listingHash, uint added, uint newTotal);
     event _Withdrawal(bytes32 indexed listingHash, uint withdrew, uint newTotal);
     event _ApplicationWhitelisted(bytes32 indexed listingHash);

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -11,8 +11,8 @@ contract Registry {
     // EVENTS
     // ------
 
-    event _Application(bytes32 indexed listingHash, uint deposit, uint appEndDate, string data);
-    event _Challenge(bytes32 indexed listingHash, uint challengeID, string data, uint commitEndDate, uint revealEndDate);
+    event _Application(bytes32 indexed listingHash, uint deposit, uint appEndDate, string data, address msgSender);
+    event _Challenge(bytes32 indexed listingHash, uint challengeID, string data, uint commitEndDate, uint revealEndDate, address msgSender);
     event _Deposit(bytes32 indexed listingHash, uint added, uint newTotal);
     event _Withdrawal(bytes32 indexed listingHash, uint withdrew, uint newTotal);
     event _ApplicationWhitelisted(bytes32 indexed listingHash);
@@ -104,7 +104,7 @@ contract Registry {
         // Transfers tokens from user to Registry contract
         require(token.transferFrom(listing.owner, this, _amount));
 
-        _Application(_listingHash, _amount, listing.applicationExpiry, _data);
+        _Application(_listingHash, _amount, listing.applicationExpiry, _data, msg.sender);
     }
 
     /**
@@ -213,7 +213,7 @@ contract Registry {
 
         var (commitEndDate, revealEndDate,) = voting.pollMap(pollID);
 
-        _Challenge(_listingHash, pollID, _data, commitEndDate, revealEndDate);
+        _Challenge(_listingHash, pollID, _data, commitEndDate, revealEndDate, msg.sender);
         return pollID;
     }
 

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -11,8 +11,8 @@ contract Registry {
     // EVENTS
     // ------
 
-    event _Application(bytes32 indexed listingHash, uint deposit, uint appEndDate, string data, address msgSender);
-    event _Challenge(bytes32 indexed listingHash, uint challengeID, string data, uint commitEndDate, uint revealEndDate, address msgSender);
+    event _Application(bytes32 indexed listingHash, uint deposit, uint appEndDate, string data, address applicant);
+    event _Challenge(bytes32 indexed listingHash, uint challengeID, string data, uint commitEndDate, uint revealEndDate, address challenger);
     event _Deposit(bytes32 indexed listingHash, uint added, uint newTotal);
     event _Withdrawal(bytes32 indexed listingHash, uint withdrew, uint newTotal);
     event _ApplicationWhitelisted(bytes32 indexed listingHash);


### PR DESCRIPTION
In Solidity, there is a difference between `tx.origin` and `msg.sender`.
With regard to the RPC method `eth_getTransactionByHash`, `from` will
always return `tx.origin`. In many cases, `tx.origin` and `msg.sender`
will have the same value. However, if the transaction utilizes a multisig
contract, there is no direct method of retrieving the multisig's address.
This commit addresses this circumstance by increasing the available data
produced by 2 events: `_Application` & `_Challenge`

* add `msg.sender` as an event emission argument to 2 events