### PR TITLE
increase default config minDeposit and pMinDeposit

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -1,7 +1,7 @@
 {
   "paramDefaults": {
-    "minDeposit": 10,
-    "pMinDeposit": 100,
+    "minDeposit": 10000000000000000000,
+    "pMinDeposit": 100000000000000000000,
     "applyStageLength": 600,
     "pApplyStageLength": 1200,
     "commitStageLength": 600,


### PR DESCRIPTION
Add 18 zeros to the ends of `minDeposit` and `pMinDeposit` default config parameters to account for token decimals