### PR TITLE
WIP Delayed exit

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -12,7 +12,8 @@
     "pDispensationPct": 50,
     "voteQuorum": 50,
     "pVoteQuorum": 50,
-    "exitTimeDelay": 600
+    "exitTimeDelay": 600,
+    "exitTimeExpiry": 600
 	},
   "name": "The TestChain Registry",
   "token": {

--- a/conf/config.json
+++ b/conf/config.json
@@ -11,7 +11,9 @@
     "dispensationPct": 50,
     "pDispensationPct": 50,
     "voteQuorum": 50,
-    "pVoteQuorum": 50
+    "pVoteQuorum": 50,
+    "exitTimeDelay": 600,
+    "pExitTimeDelay": 1200
 	},
   "name": "The TestChain Registry",
   "token": {

--- a/conf/config.json
+++ b/conf/config.json
@@ -12,8 +12,7 @@
     "pDispensationPct": 50,
     "voteQuorum": 50,
     "pVoteQuorum": 50,
-    "exitTimeDelay": 600,
-    "pExitTimeDelay": 1200
+    "exitTimeDelay": 600
 	},
   "name": "The TestChain Registry",
   "token": {

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -98,8 +98,7 @@ contract Parameterizer {
     uint _pDispensationPct,
     uint _voteQuorum,
     uint _pVoteQuorum,
-    uint _exitTimeDelay,
-    uint _pExitTimeDelay
+    uint _exitTimeDelay
     ) public {
       token = EIP20Interface(_tokenAddr);
       voting = PLCRVoting(_plcrAddr);
@@ -117,7 +116,6 @@ contract Parameterizer {
       set("voteQuorum", _voteQuorum);
       set("pVoteQuorum", _pVoteQuorum);
       set("exitTimeDelay", _exitTimeDelay);
-      set("pExitTimeDelay", _pExitTimeDelay);
   }
 
   // -----------------------

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -81,6 +81,7 @@ contract Parameterizer {
   @param _pRevealStageLen length of reveal period for voting in parameterizer
   @param _voteQuorum       type of majority out of 100 necessary for vote success
   @param _pVoteQuorum      type of majority out of 100 necessary for vote success in parameterizer
+  @param _exitTimeDelay	    length of waiting time to leave listing
   */
   function Parameterizer(
     address _tokenAddr,
@@ -96,7 +97,8 @@ contract Parameterizer {
     uint _dispensationPct,
     uint _pDispensationPct,
     uint _voteQuorum,
-    uint _pVoteQuorum
+    uint _pVoteQuorum,
+    uint _exitTimeDelay
     ) public {
       token = EIP20Interface(_tokenAddr);
       voting = PLCRVoting(_plcrAddr);
@@ -113,6 +115,7 @@ contract Parameterizer {
       set("pDispensationPct", _pDispensationPct);
       set("voteQuorum", _voteQuorum);
       set("pVoteQuorum", _pVoteQuorum);
+      set("exitTimeDelay", _exitTimeDelay);
   }
 
   // -----------------------

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -98,7 +98,8 @@ contract Parameterizer {
     uint _pDispensationPct,
     uint _voteQuorum,
     uint _pVoteQuorum,
-    uint _exitTimeDelay
+    uint _exitTimeDelay,
+    uint _exitTimeExpiry
     ) public {
       token = EIP20Interface(_tokenAddr);
       voting = PLCRVoting(_plcrAddr);
@@ -116,6 +117,7 @@ contract Parameterizer {
       set("voteQuorum", _voteQuorum);
       set("pVoteQuorum", _pVoteQuorum);
       set("exitTimeDelay", _exitTimeDelay);
+      set("exitTimeExpiry", _exitTimeExpiry);
   }
 
   // -----------------------

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -98,7 +98,8 @@ contract Parameterizer {
     uint _pDispensationPct,
     uint _voteQuorum,
     uint _pVoteQuorum,
-    uint _exitTimeDelay
+    uint _exitTimeDelay,
+    uint _pExitTimeDelay
     ) public {
       token = EIP20Interface(_tokenAddr);
       voting = PLCRVoting(_plcrAddr);
@@ -116,6 +117,7 @@ contract Parameterizer {
       set("voteQuorum", _voteQuorum);
       set("pVoteQuorum", _pVoteQuorum);
       set("exitTimeDelay", _exitTimeDelay);
+      set("pExitTimeDelay", _pExitTimeDelay);
   }
 
   // -----------------------

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -157,7 +157,7 @@ contract Parameterizer {
 
     require(token.transferFrom(msg.sender, this, deposit)); // escrow tokens (deposit amt)
 
-    _ReparameterizationProposal(_name, _value, propID, deposit, proposals[propID].appExpiry, msg.sender);
+    emit _ReparameterizationProposal(_name, _value, propID, deposit, proposals[propID].appExpiry, msg.sender);
     return propID;
   }
 
@@ -191,9 +191,11 @@ contract Parameterizer {
     //take tokens from challenger
     require(token.transferFrom(msg.sender, this, deposit));
 
-    var (commitEndDate, revealEndDate,) = voting.pollMap(pollID);
+    uint commitEndDate;
+    uint revealEndDate;
+    (commitEndDate, revealEndDate,) = voting.pollMap(pollID);
 
-    _NewChallenge(_propID, pollID, commitEndDate, revealEndDate, msg.sender);
+    emit _NewChallenge(_propID, pollID, commitEndDate, revealEndDate, msg.sender);
     return pollID;
   }
 
@@ -213,7 +215,7 @@ contract Parameterizer {
       // There is no challenge against the proposal. The processBy date for the proposal has not
      // passed, but the proposal's appExpirty date has passed.
       set(prop.name, prop.value);
-      _ProposalAccepted(_propID, prop.name, prop.value);
+      emit _ProposalAccepted(_propID, prop.name, prop.value);
       delete proposals[_propID];
       require(token.transfer(propOwner, propDeposit));
     } else if (challengeCanBeResolved(_propID)) {
@@ -221,7 +223,7 @@ contract Parameterizer {
       resolveChallenge(_propID);
     } else if (now > prop.processBy) {
       // There is no challenge against the proposal, but the processBy date has passed.
-      _ProposalExpired(_propID);
+      emit _ProposalExpired(_propID);
       delete proposals[_propID];
       require(token.transfer(propOwner, propDeposit));
     } else {
@@ -263,7 +265,7 @@ contract Parameterizer {
     // ensures a voter cannot claim tokens again
     challenges[_challengeID].tokenClaims[msg.sender] = true;
 
-    _RewardClaimed(_challengeID, reward, msg.sender);
+    emit _RewardClaimed(_challengeID, reward, msg.sender);
     require(token.transfer(msg.sender, reward));
   }
 
@@ -369,11 +371,11 @@ contract Parameterizer {
       if(prop.processBy > now) {
         set(prop.name, prop.value);
       }
-      _ChallengeFailed(_propID, prop.challengeID, challenge.rewardPool, challenge.winningTokens);
+      emit _ChallengeFailed(_propID, prop.challengeID, challenge.rewardPool, challenge.winningTokens);
       require(token.transfer(prop.owner, reward));
     }
     else { // The challenge succeeded or nobody voted
-      _ChallengeSucceeded(_propID, prop.challengeID, challenge.rewardPool, challenge.winningTokens);
+      emit _ChallengeSucceeded(_propID, prop.challengeID, challenge.rewardPool, challenge.winningTokens);
       require(token.transfer(challenges[prop.challengeID].challenger, reward));
     }
   }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -175,7 +175,8 @@ contract Registry {
 
 	// Cannot exit during ongoing challenge
 	require(listing.challengeID == 0 || challenges[listing.challengeID].resolved);
-
+	// If you initialized before you should not be able to again
+        require(listing.exitTime == 0);
 	// Set when the listing may be removed from the whitelist
 	listing.exitTime = block.timestamp.add(parameterizer.get("exitTimeDelay"));
 	emit _ExitInitialized(_listingHash, listing.exitTime);

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -199,8 +199,9 @@ contract Registry {
 	require(listing.exitTime > 0);
 
 	// Make sure time has elapsed passed the exit time
-	require(block.timestamp >= listing.exitTime);
-
+	// require(block.timestamp >= listing.exitTime);
+        require(listing.exitTime < block.timestamp && (block.timestamp <
+						       listing.exitTime.add(parameterizer.get("exitTimeExpiry"))));
 	resetListing(_listingHash);
 	emit _ListingWithdrawn(_listingHash, msg.sender);
     }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -18,7 +18,7 @@ contract Registry {
     event _ApplicationWhitelisted(bytes32 indexed listingHash);
     event _ApplicationRemoved(bytes32 indexed listingHash);
     event _ListingRemoved(bytes32 indexed listingHash);
-    event _ListingWithdrawn(bytes32 indexed listingHash);
+    event _ListingWithdrawn(bytes32 indexed listingHash, address indexed owner);
     event _TouchAndRemoved(bytes32 indexed listingHash);
     event _ChallengeFailed(bytes32 indexed listingHash, uint indexed challengeID, uint rewardPool, uint totalTokens);
     event _ChallengeSucceeded(bytes32 indexed listingHash, uint indexed challengeID, uint rewardPool, uint totalTokens);
@@ -190,7 +190,7 @@ contract Registry {
 	Listing storage listing = listings[_listingHash];
 
 	require(msg.sender == listing.owner);
-	//require(isWhitelisted(_listingHash));
+	require(isWhitelisted(_listingHash));
 
 	// Cannot exit during ongoing challenge
 	require(listing.challengeID == 0 || challenges[listing.challengeID].resolved);
@@ -202,7 +202,7 @@ contract Registry {
 	require(block.timestamp >= listing.exitTime);
 
 	resetListing(_listingHash);
-	emit _ListingWithdrawn(_listingHash);
+	emit _ListingWithdrawn(_listingHash, msg.sender);
     }
 
     // -----------------------

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -163,6 +163,10 @@ contract Registry {
     // }
 
     
+    /**
+    @dev		Initialize an exit timer for a listing to leave the whitelist
+    @param _listingHash	A listing hash msg.sender is the owner of
+    */
     function initExit(bytes32 _listingHash) external {	
 	Listing storage listing = listings[_listingHash];
 
@@ -172,11 +176,16 @@ contract Registry {
 	// Cannot exit during ongoing challenge
 	require(listing.challengeID == 0 || challenges[listing.challengeID].resolved);
 
+	// Set when the listing may be removed from the whitelist
 	listing.exitTime = block.timestamp.add(parameterizer.get("exitTimeDelay"));
 	emit _ExitInitialized(_listingHash, listing.exitTime);
     }
 
-    function finializeExit(bytes32 _listingHash) external {
+    /**
+    @dev		Allow a listing to leave the whitelist
+    @param _listingHash A listing hash msg.sender is the owner of
+    */
+    function finalizeExit(bytes32 _listingHash) external {
 	Listing storage listing = listings[_listingHash];
 
 	require(msg.sender == listing.owner);
@@ -185,7 +194,10 @@ contract Registry {
 	// Cannot exit during ongoing challenge
 	require(listing.challengeID == 0 || challenges[listing.challengeID].resolved);
 
+	// Make sure the exit was initialized
 	require(listing.exitTime > 0);
+
+	// Make sure time has elapsed passed the exit time
 	require(block.timestamp >= listing.exitTime);
 
 	resetListing(_listingHash);

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -23,7 +23,7 @@ contract Registry {
     event _ChallengeFailed(bytes32 indexed listingHash, uint indexed challengeID, uint rewardPool, uint totalTokens);
     event _ChallengeSucceeded(bytes32 indexed listingHash, uint indexed challengeID, uint rewardPool, uint totalTokens);
     event _RewardClaimed(uint indexed challengeID, uint reward, address indexed voter);
-    event _ExitInitialized(bytes32 indexed listingHash, uint exitTime);
+    event _ExitInitialized(bytes32 indexed listingHash, uint exitTime, address indexed owner);
 
     using SafeMath for uint;
 
@@ -179,7 +179,7 @@ contract Registry {
         require(listing.exitTime == 0);
 	// Set when the listing may be removed from the whitelist
 	listing.exitTime = block.timestamp.add(parameterizer.get("exitTimeDelay"));
-	emit _ExitInitialized(_listingHash, listing.exitTime);
+	emit _ExitInitialized(_listingHash, listing.exitTime, msg.sender);
     }
 
     /**

--- a/migrations/5_deploy_parameterizer.js
+++ b/migrations/5_deploy_parameterizer.js
@@ -46,6 +46,8 @@ module.exports = (deployer, network, accounts) => {
       parameterizerConfig.pDispensationPct,
       parameterizerConfig.voteQuorum,
       parameterizerConfig.pVoteQuorum,
+      parameterizerConfig.exitTimeDelay,
+      parameterizerConfig.pExitTimeDelay,
     );
   })
     .then(async () => {

--- a/migrations/5_deploy_parameterizer.js
+++ b/migrations/5_deploy_parameterizer.js
@@ -47,6 +47,7 @@ module.exports = (deployer, network, accounts) => {
       parameterizerConfig.voteQuorum,
       parameterizerConfig.pVoteQuorum,
       parameterizerConfig.exitTimeDelay,
+      parameterizerConfig.exitTimeExpiry,
     );
   })
     .then(async () => {

--- a/migrations/5_deploy_parameterizer.js
+++ b/migrations/5_deploy_parameterizer.js
@@ -47,7 +47,6 @@ module.exports = (deployer, network, accounts) => {
       parameterizerConfig.voteQuorum,
       parameterizerConfig.pVoteQuorum,
       parameterizerConfig.exitTimeDelay,
-      parameterizerConfig.pExitTimeDelay,
     );
   })
     .then(async () => {

--- a/test/registry/appWasMade.js
+++ b/test/registry/appWasMade.js
@@ -39,7 +39,10 @@ contract('Registry', (accounts) => {
       assert.strictEqual(resultThree, true, 'should have returned true because its whitelisted');
 
       // Exit
-      await utils.as(applicant, registry.exit, listing);
+      await registry.initExit(listing, { from: applicant });
+      await utils.increaseTime(paramConfig.exitTimeDelay + 1);
+      await registry.finalizeExit(listing, { from: applicant });
+      // await utils.as(applicant, registry.exit, listing);
       const resultFour = await registry.appWasMade(listing);
       assert.strictEqual(resultFour, false, 'should have returned false because exit');
     });

--- a/test/registry/exit.js
+++ b/test/registry/exit.js
@@ -13,7 +13,7 @@ const BigNumber = require('bignumber.js');
 
 contract('Registry', (accounts) => {
   describe('Function: exit', () => {
-    const [applicant, challenger, voter] = accounts;
+    const [applicant, challenger] = accounts;
 
     it('should allow a listing to exit when no challenge exists', async () => {
       const registry = await Registry.deployed();
@@ -30,9 +30,6 @@ contract('Registry', (accounts) => {
       await utils.increaseTime(paramConfig.exitTimeDelay + 1);
       await registry.finalizeExit(listing, { from: applicant });
 
-      const listingStruct = await registry.listings.call(listing);
-      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time did not reset');
-
       const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
       assert.strictEqual(isWhitelistedAfterExit, false, 'the listing was not removed on exit');
 
@@ -42,6 +39,9 @@ contract('Registry', (accounts) => {
         finalApplicantTokenHoldings.toString(10),
         'the applicant\'s tokens were not returned to them after exiting the registry',
       );
+
+      const listingStruct = await registry.listings.call(listing);
+      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time did not reset');
     });
 
     it('should not allow a listing to finalize exit when exit was not initialized', async () => {
@@ -68,8 +68,8 @@ contract('Registry', (accounts) => {
 
       const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
       assert.strictEqual(
-        finalApplicantTokenHoldings.add(paramConfig.minDeposit).toString(),
-        initialApplicantTokenHoldings.toString(),
+        finalApplicantTokenHoldings.toString(),
+        initialApplicantTokenHoldings.sub(paramConfig.minDeposit).toString(),
         'the applicant\'s tokens were returned in spite of failing to exit',
       );
 
@@ -89,6 +89,7 @@ contract('Registry', (accounts) => {
       const isWhitelisted = await registry.isWhitelisted.call(listing);
       assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
       await registry.initExit(listing, { from: applicant });
+      // blockTimestamp is used to calculate when the applicant's exit time is up
       const blockTimestamp = new BigNumber(await utils.getBlockTimestamp());
       try {
         await registry.finalizeExit(listing, { from: applicant });
@@ -102,51 +103,12 @@ contract('Registry', (accounts) => {
 
       const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
       assert.strictEqual(
-        finalApplicantTokenHoldings.add(paramConfig.minDeposit).toString(),
-        initialApplicantTokenHoldings.toString(),
+        finalApplicantTokenHoldings.toString(),
+        initialApplicantTokenHoldings.sub(paramConfig.minDeposit).toString(),
         'the applicant\'s tokens were returned in spite of failing to exit',
       );
       const listingStruct = await registry.listings.call(listing);
       assert.strictEqual(listingStruct[5].toString(), blockTimestamp.add(paramConfig.exitTimeDelay).toString(), 'exit time was not initialized');
-    });
-
-    it('should not allow a listing to initialize an exit when a challenge exists', async () => {
-      const registry = await Registry.deployed();
-      const token = Token.at(await registry.token.call());
-      const listing = utils.getListingHash('420.com');
-
-      const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
-
-      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
-
-      const isWhitelisted = await registry.isWhitelisted.call(listing);
-      assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
-
-      await registry.challenge(listing, '', { from: challenger });
-      try {
-        await registry.initExit(listing, { from: applicant });
-        assert(false, 'exit succeeded when it should have failed');
-      } catch (err) {
-        const errMsg = err.toString();
-        assert(utils.isEVMException(err), errMsg);
-      }
-
-      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
-      assert.strictEqual(
-        isWhitelistedAfterExit,
-        true,
-        'the listing was able to exit while a challenge was active',
-      );
-
-      const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
-      assert.strictEqual(
-        finalApplicantTokenHoldings.add(paramConfig.minDeposit).toString(),
-        initialApplicantTokenHoldings.toString(),
-        'the applicant\'s tokens were returned in spite of failing to exit',
-      );
-
-      const listingStruct = await registry.listings.call(listing);
-      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time was initialized');
     });
 
     it('should not allow a listing to finalize an exit when a challenge does exist', async () => {
@@ -162,9 +124,13 @@ contract('Registry', (accounts) => {
       assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
 
       await registry.initExit(listing, { from: applicant });
+      // blockTimestamp is used to calculate when the applicant's exit time is up
       const blockTimestamp = new BigNumber(await utils.getBlockTimestamp());
       await utils.increaseTime(paramConfig.exitTimeDelay + 1);
       await registry.challenge(listing, '', { from: challenger });
+      // Make an assertion to prove that challenge does exit
+      const initialListingStruct = await registry.listings.call(listing);
+      assert.notStrictEqual(initialListingStruct[4].toString(), '0', 'Challenge was never created');
       try {
         await registry.finalizeExit(listing, { from: applicant });
         assert(false, 'exit succeeded when it should have failed');
@@ -179,76 +145,14 @@ contract('Registry', (accounts) => {
         true,
         'the listing was able to exit while a challenge was active',
       );
-
       const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
       assert.strictEqual(
-        finalApplicantTokenHoldings.add(paramConfig.minDeposit).toString(),
-        initialApplicantTokenHoldings.toString(),
+        finalApplicantTokenHoldings.toString(),
+        initialApplicantTokenHoldings.sub(paramConfig.minDeposit).toString(),
         'the applicant\'s tokens were returned in spite of failing to exit',
       );
-
       const listingStruct = await registry.listings.call(listing);
       assert.strictEqual(listingStruct[5].toString(), blockTimestamp.add(paramConfig.exitTimeDelay).toString(), 'exit time was not initialized');
     });
-
-    // REFACTOR THE FOLLOWING TWO TESTS
-    it('should not initialize an exit by someone who doesn\'t own the listing', async () => {
-      const registry = await Registry.deployed();
-      const listing = utils.getListingHash('chilling.com');
-
-      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
-
-      try {
-        await registry.initExit(listing, { from: voter });
-        assert(false, 'exit initialized when it should have failed');
-      } catch (err) {
-        const errMsg = err.toString();
-        assert(utils.isEVMException(err), errMsg);
-      }
-      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
-      assert.strictEqual(
-        isWhitelistedAfterExit,
-        true,
-        'the listing was initialized by someone other than its owner',
-      );
-    });
-
-    it('should not finalize an exit by someone who doesn\'t own the listing', async () => {
-      const registry = await Registry.deployed();
-      const listing = utils.getListingHash('helpme.com');
-
-      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
-      await registry.initExit(listing, { from: applicant });
-      await utils.increaseTime(paramConfig.exitTimeDelay + 1);
-      try {
-        await registry.finalizeExit(listing, { from: voter });
-        assert(false, 'exit finalized when it should have failed');
-      } catch (err) {
-        const errMsg = err.toString();
-        assert(utils.isEVMException(err), errMsg);
-      }
-      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
-      assert.strictEqual(
-        isWhitelistedAfterExit,
-        true,
-        'the listing was initialized by someone other than its owner',
-      );
-    });
-
-    it('should revert if listing is in application stage', async () => {
-      const registry = await Registry.deployed();
-      const listing = utils.getListingHash('nogoodnames.com');
-
-      await utils.as(applicant, registry.apply, listing, paramConfig.minDeposit, '');
-
-      try {
-        await registry.initExit(listing, { from: applicant });
-      } catch (err) {
-        assert(utils.isEVMException(err), err.toString());
-        return;
-      }
-      assert(false, 'exit succeeded for non-whitelisted listing');
-    });
   });
 });
-

--- a/test/registry/exit.js
+++ b/test/registry/exit.js
@@ -17,7 +17,7 @@ contract('Registry', (accounts) => {
     it('should allow a listing to exit when no challenge exists', async () => {
       const registry = await Registry.deployed();
       const token = Token.at(await registry.token.call());
-      const listing = utils.getListingHash('consensys.net');
+      const listing = utils.getListingHash('google.com');
 
       const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
 
@@ -43,7 +43,7 @@ contract('Registry', (accounts) => {
     it('should not allow a listing to finalize exit when exit was not initialized', async () => {
       const registry = await Registry.deployed();
       const token = Token.at(await registry.token.call());
-      const listing = utils.getListingHash('consensys.net');
+      const listing = utils.getListingHash('youtube.com');
 
       const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
 
@@ -70,7 +70,7 @@ contract('Registry', (accounts) => {
     it('should not allow a listing to finalize exit when time is not up', async () => {
       const registry = await Registry.deployed();
       const token = Token.at(await registry.token.call());
-      const listing = utils.getListingHash('consensys.net');
+      const listing = utils.getListingHash('hangouts.com');
 
       const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
 
@@ -99,7 +99,7 @@ contract('Registry', (accounts) => {
     it('should not allow a listing to exit when a challenge does exist', async () => {
       const registry = await Registry.deployed();
       const token = Token.at(await registry.token.call());
-      const listing = utils.getListingHash('consensys.net');
+      const listing = utils.getListingHash('420.com');
 
       const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
 
@@ -139,7 +139,7 @@ contract('Registry', (accounts) => {
 
     it('should not initialize an exit by someone who doesn\'t own the listing', async () => {
       const registry = await Registry.deployed();
-      const listing = utils.getListingHash('consensys.net');
+      const listing = utils.getListingHash('chilling.com');
 
       await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
 
@@ -160,7 +160,7 @@ contract('Registry', (accounts) => {
 
     it('should not finalize an exit by someone who doesn\'t own the listing', async () => {
       const registry = await Registry.deployed();
-      const listing = utils.getListingHash('consensys.net');
+      const listing = utils.getListingHash('helpme.com');
 
       await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
       await registry.initExit(listing, { from: applicant });
@@ -182,12 +182,12 @@ contract('Registry', (accounts) => {
 
     it('should revert if listing is in application stage', async () => {
       const registry = await Registry.deployed();
-      const listing = utils.getListingHash('real.net');
+      const listing = utils.getListingHash('nogoodnames.com');
 
       await utils.as(applicant, registry.apply, listing, paramConfig.minDeposit, '');
 
       try {
-        await registry.exit(listing, { from: applicant });
+        await registry.initExit(listing, { from: applicant });
       } catch (err) {
         assert(utils.isEVMException(err), err.toString());
         return;

--- a/test/registry/exit.js
+++ b/test/registry/exit.js
@@ -25,8 +25,9 @@ contract('Registry', (accounts) => {
 
       const isWhitelisted = await registry.isWhitelisted.call(listing);
       assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
-
-      await registry.exit(listing, { from: applicant });
+      await registry.initExit(listing, { from: applicant });
+      await utils.increaseTime(paramConfig.exitTimeDelay + 1);
+      await registry.finalizeExit(listing, { from: applicant });
 
       const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
       assert.strictEqual(isWhitelistedAfterExit, false, 'the listing was not removed on exit');
@@ -36,6 +37,62 @@ contract('Registry', (accounts) => {
         initialApplicantTokenHoldings.toString(10),
         finalApplicantTokenHoldings.toString(10),
         'the applicant\'s tokens were not returned to them after exiting the registry',
+      );
+    });
+
+    it('should not allow a listing to finalize exit when exit was not initialized', async () => {
+      const registry = await Registry.deployed();
+      const token = Token.at(await registry.token.call());
+      const listing = utils.getListingHash('consensys.net');
+
+      const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
+
+      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
+
+      const isWhitelisted = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
+      try {
+        await registry.finalizeExit(listing, { from: applicant });
+        assert(false, 'exit succeeded when it should have failed due to exit not being initialized');
+      } catch (err) {
+        const errMsg = err.toString();
+        assert(utils.isEVMException(err), errMsg);
+      }
+      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(isWhitelistedAfterExit, true, 'the listing was removed on finalizeExit');
+      const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
+      assert(
+        initialApplicantTokenHoldings.gt(finalApplicantTokenHoldings),
+        'the applicant\'s tokens were returned in spite of failing to exit',
+      );
+    });
+
+    it('should not allow a listing to finalize exit when time is not up', async () => {
+      const registry = await Registry.deployed();
+      const token = Token.at(await registry.token.call());
+      const listing = utils.getListingHash('consensys.net');
+
+      const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
+
+      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
+
+      const isWhitelisted = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
+      await registry.initExit(listing, { from: applicant });
+      try {
+        await registry.finalizeExit(listing, { from: applicant });
+        assert(false, 'exit succeeded when it should have failed due to time not being up');
+      } catch (err) {
+        const errMsg = err.toString();
+        assert(utils.isEVMException(err), errMsg);
+      }
+      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
+      assert(isWhitelistedAfterExit, true, 'the listing was removed on finalizeExit');
+
+      const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
+      assert(
+        initialApplicantTokenHoldings.gt(finalApplicantTokenHoldings),
+        'the applicant\'s tokens were returned in spite of failing to exit',
       );
     });
 
@@ -53,7 +110,9 @@ contract('Registry', (accounts) => {
 
       await registry.challenge(listing, '', { from: challenger });
       try {
-        await registry.exit(listing, { from: applicant });
+        await registry.initExit(listing, { from: applicant });
+        await utils.increaseTime(paramConfig.exitTimeDelay + 1);
+        await registry.finalizeExit(listing, { from: applicant });
         assert(false, 'exit succeeded when it should have failed');
       } catch (err) {
         const errMsg = err.toString();
@@ -78,15 +137,15 @@ contract('Registry', (accounts) => {
       await registry.updateStatus(listing);
     });
 
-    it('should not allow a listing to be exited by someone who doesn\'t own it', async () => {
+    it('should not initialize an exit by someone who doesn\'t own the listing', async () => {
       const registry = await Registry.deployed();
       const listing = utils.getListingHash('consensys.net');
 
       await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
 
       try {
-        await registry.exit(listing, { from: voter });
-        assert(false, 'exit succeeded when it should have failed');
+        await registry.initExit(listing, { from: voter });
+        assert(false, 'exit initialized when it should have failed');
       } catch (err) {
         const errMsg = err.toString();
         assert(utils.isEVMException(err), errMsg);
@@ -95,7 +154,29 @@ contract('Registry', (accounts) => {
       assert.strictEqual(
         isWhitelistedAfterExit,
         true,
-        'the listing was exited by someone other than its owner',
+        'the listing was initialized by someone other than its owner',
+      );
+    });
+
+    it('should not finalize an exit by someone who doesn\'t own the listing', async () => {
+      const registry = await Registry.deployed();
+      const listing = utils.getListingHash('consensys.net');
+
+      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
+      await registry.initExit(listing, { from: applicant });
+      await utils.increaseTime(paramConfig.exitTimeDelay + 1);
+      try {
+        await registry.finalizeExit(listing, { from: voter });
+        assert(false, 'exit finalized when it should have failed');
+      } catch (err) {
+        const errMsg = err.toString();
+        assert(utils.isEVMException(err), errMsg);
+      }
+      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(
+        isWhitelistedAfterExit,
+        true,
+        'the listing was initialized by someone other than its owner',
       );
     });
 

--- a/test/registry/finalizeExit.js
+++ b/test/registry/finalizeExit.js
@@ -12,7 +12,7 @@ const utils = require('../utils.js');
 const BigNumber = require('bignumber.js');
 
 contract('Registry', (accounts) => {
-  describe('Function: exit', () => {
+  describe('Function: finalizeExit', () => {
     const [applicant, challenger] = accounts;
 
     it('should allow a listing to exit when no challenge exists', async () => {

--- a/test/registry/finalizeExit.js
+++ b/test/registry/finalizeExit.js
@@ -226,7 +226,7 @@ contract('Registry', (accounts) => {
       await registry.initExit(listing, { from: applicant });
       await utils.increaseTime(paramConfig.exitTimeDelay + 1);
       await registry.finalizeExit(listing, { from: applicant });
-      // ----------------------------------------
+
       const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
       assert.strictEqual(
         isWhitelistedAfterExit,

--- a/test/registry/initExit.js
+++ b/test/registry/initExit.js
@@ -12,7 +12,7 @@ const utils = require('../utils.js');
 const BigNumber = require('bignumber.js');
 
 contract('Registry', (accounts) => {
-  describe('Function: exit', () => {
+  describe('Function: initExit', () => {
     const [applicant, challenger] = accounts;
 
     it('exit time state should be correctly set', async () => {
@@ -100,7 +100,7 @@ contract('Registry', (accounts) => {
       );
 
       const listingStruct = await registry.listings.call(listing);
-      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time was initialized');
+      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time should not have been initialized');
     });
 
     it('should revert if listing is in application stage', async () => {
@@ -123,7 +123,7 @@ contract('Registry', (accounts) => {
       assert(false, 'exit succeeded for non-whitelisted listing');
 
       const listingStruct = await registry.listings.call(listing);
-      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time was initialized');
+      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time should not have been initialized');
     });
   });
 });

--- a/test/registry/initExit.js
+++ b/test/registry/initExit.js
@@ -1,0 +1,130 @@
+/* eslint-env mocha */
+/* global assert contract artifacts */
+const Registry = artifacts.require('Registry.sol');
+const Token = artifacts.require('EIP20.sol');
+
+const fs = require('fs');
+
+const config = JSON.parse(fs.readFileSync('./conf/config.json'));
+const paramConfig = config.paramDefaults;
+
+const utils = require('../utils.js');
+const BigNumber = require('bignumber.js');
+
+contract('Registry', (accounts) => {
+  describe('Function: exit', () => {
+    const [applicant, challenger] = accounts;
+
+    it('exit time state should be correctly set', async () => {
+      const registry = await Registry.deployed();
+      const token = Token.at(await registry.token.call());
+      const listing = utils.getListingHash('hangoutz.com');
+
+      const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
+
+      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
+
+      const isWhitelisted = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
+      await registry.initExit(listing, { from: applicant });
+      // blockTimestamp is used to calculate when the applicant's exit time is up
+      const blockTimestamp = new BigNumber(await utils.getBlockTimestamp());
+
+      const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
+      assert.strictEqual(
+        finalApplicantTokenHoldings.toString(),
+        initialApplicantTokenHoldings.sub(paramConfig.minDeposit).toString(),
+        'the applicant\'s tokens were returned in spite of exit',
+      );
+      const listingStruct = await registry.listings.call(listing);
+      assert.strictEqual(listingStruct[5].toString(), blockTimestamp.add(paramConfig.exitTimeDelay).toString(), 'exit time was not initialized');
+    });
+
+    it('should not allow a listing to initialize an exit when a challenge exists', async () => {
+      const registry = await Registry.deployed();
+      const token = Token.at(await registry.token.call());
+      const listing = utils.getListingHash('420.com');
+
+      const initialApplicantTokenHoldings = await token.balanceOf.call(applicant);
+
+      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
+
+      const isWhitelisted = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(isWhitelisted, true, 'the listing was not added to the registry');
+
+      await registry.challenge(listing, '', { from: challenger });
+      try {
+        await registry.initExit(listing, { from: applicant });
+        assert(false, 'exit succeeded when it should have failed');
+      } catch (err) {
+        const errMsg = err.toString();
+        assert(utils.isEVMException(err), errMsg);
+      }
+
+      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(
+        isWhitelistedAfterExit,
+        true,
+        'the listing was able to exit while a challenge was active',
+      );
+
+      const finalApplicantTokenHoldings = await token.balanceOf.call(applicant);
+      assert.strictEqual(
+        finalApplicantTokenHoldings.toString(),
+        initialApplicantTokenHoldings.sub(paramConfig.minDeposit).toString(),
+        'the applicant\'s tokens were returned in spite of failing to exit',
+      );
+
+      const listingStruct = await registry.listings.call(listing);
+      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time was initialized');
+    });
+
+    it('should not initialize an exit by someone who doesn\'t own the listing', async () => {
+      const registry = await Registry.deployed();
+      const listing = utils.getListingHash('chilling.com');
+
+      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant);
+
+      try {
+        await registry.initExit(listing, { from: challenger });
+        assert(false, 'exit initialized when it should have failed');
+      } catch (err) {
+        const errMsg = err.toString();
+        assert(utils.isEVMException(err), errMsg);
+      }
+      const isWhitelistedAfterExit = await registry.isWhitelisted.call(listing);
+      assert.strictEqual(
+        isWhitelistedAfterExit,
+        true,
+        'the listing was initialized by someone other than its owner',
+      );
+
+      const listingStruct = await registry.listings.call(listing);
+      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time was initialized');
+    });
+
+    it('should revert if listing is in application stage', async () => {
+      const registry = await Registry.deployed();
+      const listing = utils.getListingHash('nogoodnames.com');
+
+      await utils.as(applicant, registry.apply, listing, paramConfig.minDeposit, '');
+
+      const initialListingStruct = await registry.listings.call(listing);
+      // Getting blockTimestamp to prove the listing is indeed in application stage
+      const blockTimestamp = new BigNumber(await utils.getBlockTimestamp());
+      // Checking to see if the listing is still in application stage
+      assert((initialListingStruct[0] > 0 && initialListingStruct[0] > blockTimestamp), 'Listing is not in application stage ');
+      try {
+        await registry.initExit(listing, { from: applicant });
+      } catch (err) {
+        assert(utils.isEVMException(err), err.toString());
+        return;
+      }
+      assert(false, 'exit succeeded for non-whitelisted listing');
+
+      const listingStruct = await registry.listings.call(listing);
+      assert.strictEqual(listingStruct[5].toString(), '0', 'exit time was initialized');
+    });
+  });
+});
+

--- a/test/registry/updateStatus.js
+++ b/test/registry/updateStatus.js
@@ -92,8 +92,10 @@ contract('Registry', (accounts) => {
       await utils.addToWhitelist(listing, minDeposit, applicant);
       const resultOne = await registry.isWhitelisted(listing);
       assert.strictEqual(resultOne, true, 'Listing should have been whitelisted');
-
-      await utils.as(applicant, registry.exit, listing);
+      await registry.initExit(listing, { from: applicant });
+      await utils.increaseTime(paramConfig.exitTimeDelay + 1);
+      await registry.finalizeExit(listing, { from: applicant });
+      // await utils.as(applicant, registry.exit, listing);
       const resultTwo = await registry.isWhitelisted(listing);
       assert.strictEqual(resultTwo, false, 'Listing should not be in the whitelist');
 


### PR DESCRIPTION
With old exit function, anybody could leave without any repercussions. E.x. a bad actor does something bad on the whitelist and decides to exit before being challenged and they are transferred back their original unstaked deposit. By increasing the time in which one is required to finalize an exit, we can mitigate this.

* Split up exit function into two, initExit() and finalizeExit(). 

* Add two parameters to Parameterizer: `exitTimeDelay` and `exitTimeExpiry`. `exitTimeDelay` represents the first time that the user is allowed to finalize their exit while `exitTimeExpiry` represents the latest time.

* Add tests. Refactor a few tests to contain less state.

Will rebase against develop before final review.