### PR TITLE
Change `before()` to `beforeEach()` and change config file

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -1,7 +1,7 @@
 {
   "paramDefaults": {
-    "minDeposit": 10,
-    "pMinDeposit": 100,
+    "minDeposit": 10000000000000000000,
+    "pMinDeposit": 100000000000000000000,
     "applyStageLength": 600,
     "pApplyStageLength": 1200,
     "commitStageLength": 600,

--- a/test/ParameterizerFactory/newParameterizerBYOToken.js
+++ b/test/ParameterizerFactory/newParameterizerBYOToken.js
@@ -13,7 +13,7 @@ contract('ParameterizerFactory', (accounts) => {
   describe('Function: newParameterizerBYOToken', () => {
     let parameterizerFactory;
 
-    before(async () => {
+    beforeEach(async () => {
       parameterizerFactory = await ParameterizerFactory.deployed();
     });
 

--- a/test/ParameterizerFactory/newParameterizerWithToken.js
+++ b/test/ParameterizerFactory/newParameterizerWithToken.js
@@ -12,7 +12,7 @@ contract('ParameterizerFactory', (accounts) => {
   describe('Function: newParameterizerWithToken', () => {
     let parameterizerFactory;
 
-    before(async () => {
+    beforeEach(async () => {
       parameterizerFactory = await ParameterizerFactory.deployed();
     });
 

--- a/test/RegistryFactory/newRegistryBYOToken.js
+++ b/test/RegistryFactory/newRegistryBYOToken.js
@@ -13,7 +13,7 @@ contract('RegistryFactory', (accounts) => {
   describe('Function: newRegistryBYOToken', () => {
     let registryFactory;
 
-    before(async () => {
+    beforeEach(async () => {
       registryFactory = await RegistryFactory.deployed();
     });
 

--- a/test/RegistryFactory/newRegistryWithToken.js
+++ b/test/RegistryFactory/newRegistryWithToken.js
@@ -13,7 +13,7 @@ contract('RegistryFactory', (accounts) => {
   describe('Function: newRegistryWithToken', () => {
     let registryFactory;
 
-    before(async () => {
+    beforeEach(async () => {
       registryFactory = await RegistryFactory.deployed();
     });
 

--- a/test/parameterizer/canBeSet.js
+++ b/test/parameterizer/canBeSet.js
@@ -13,7 +13,7 @@ contract('Parameterizer', (accounts) => {
     let token;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { paramProxy, tokenInstance } = await utils.getProxies();
       parameterizer = paramProxy;
       token = tokenInstance;

--- a/test/parameterizer/challengeCanBeResolved.js
+++ b/test/parameterizer/challengeCanBeResolved.js
@@ -13,7 +13,7 @@ contract('Parameterizer', (accounts) => {
     let token;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { paramProxy, tokenInstance } = await utils.getProxies();
       parameterizer = paramProxy;
       token = tokenInstance;

--- a/test/parameterizer/challengeReparameterization.js
+++ b/test/parameterizer/challengeReparameterization.js
@@ -15,7 +15,7 @@ contract('Parameterizer', (accounts) => {
     let voting;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, paramProxy, tokenInstance } = await utils.getProxies(token);
       voting = votingProxy;
       parameterizer = paramProxy;

--- a/test/parameterizer/challengeReparameterization.js
+++ b/test/parameterizer/challengeReparameterization.js
@@ -43,7 +43,8 @@ contract('Parameterizer', (accounts) => {
         'should have been successfully challenged');
 
       const proposerFinalBalance = await token.balanceOf.call(proposer);
-      const proposerExpected = proposerStartingBalance.sub(new BN(paramConfig.pMinDeposit, 10));
+      const proposerExpected = proposerStartingBalance
+        .sub(new BN(paramConfig.pMinDeposit.toString(), 10));
       assert.strictEqual(
         proposerFinalBalance.toString(10), proposerExpected.toString(10),
         'The challenge loser\'s token balance is not as expected',
@@ -51,7 +52,8 @@ contract('Parameterizer', (accounts) => {
 
       // Edge case, challenger gets both deposits back because there were no voters
       const challengerFinalBalance = await token.balanceOf.call(challenger);
-      const challengerExpected = challengerStartingBalance.add(new BN(paramConfig.pMinDeposit, 10));
+      const challengerExpected = challengerStartingBalance
+        .add(new BN(paramConfig.pMinDeposit.toString(), 10));
       assert.strictEqual(
         challengerFinalBalance.toString(10), challengerExpected.toString(10),
         'The challenge winner\'s token balance is not as expected',
@@ -93,7 +95,8 @@ contract('Parameterizer', (accounts) => {
       );
 
       const challengerFinalBalance = await token.balanceOf.call(challenger);
-      const challengerExpected = challengerStartingBalance.sub(new BN(paramConfig.pMinDeposit, 10));
+      const challengerExpected = challengerStartingBalance
+        .sub(new BN(paramConfig.pMinDeposit.toString(), 10));
       assert.strictEqual(
         challengerFinalBalance.toString(10), challengerExpected.toString(10),
         'The challenge loser\'s token balance is not as expected',
@@ -106,7 +109,7 @@ contract('Parameterizer', (accounts) => {
         // make proposal to change pMinDeposit
         // this is to induce an error where:
         // a challenge could have a different stake than the proposal being challenged
-        const proposalReceiptOne = await utils.as(proposer, parameterizer.proposeReparameterization, 'pMinDeposit', paramConfig.pMinDeposit + 1);
+        const proposalReceiptOne = await utils.as(proposer, parameterizer.proposeReparameterization, 'pMinDeposit', paramConfig.pMinDeposit * 10);
         const propIDOne = proposalReceiptOne.logs[0].args.propID;
 
         // increase time

--- a/test/parameterizer/claimReward.js
+++ b/test/parameterizer/claimReward.js
@@ -18,7 +18,7 @@ contract('Parameterizer', (accounts) => {
     let parameterizer;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const {
         votingProxy, paramProxy, registryProxy, tokenInstance,
       } = await utils.getProxies(token);

--- a/test/parameterizer/claimRewards.js
+++ b/test/parameterizer/claimRewards.js
@@ -14,7 +14,7 @@ contract('Parameterizer', (accounts) => {
     let voting;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const {
         votingProxy, paramProxy, tokenInstance,
       } = await utils.getProxies(token);

--- a/test/parameterizer/get.js
+++ b/test/parameterizer/get.js
@@ -12,7 +12,7 @@ contract('Parameterizer', (accounts) => {
     let voting;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, paramProxy, tokenInstance } = await utils.getProxies(token);
       voting = votingProxy;
       parameterizer = paramProxy;

--- a/test/parameterizer/processProposal.js
+++ b/test/parameterizer/processProposal.js
@@ -16,7 +16,7 @@ contract('Parameterizer', (accounts) => {
     let parameterizer;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const {
         votingProxy, paramProxy, registryProxy, tokenInstance,
       } = await utils.getProxies(token);

--- a/test/parameterizer/processProposal.js
+++ b/test/parameterizer/processProposal.js
@@ -88,7 +88,7 @@ contract('Parameterizer', (accounts) => {
 
       const voteQuorum = await parameterizer.get.call('voteQuorum');
       assert.strictEqual(
-        voteQuorum.toString(10), '51',
+        voteQuorum.toString(10), '50',
         'A proposal whose processBy date passed was able to update the parameterizer',
       );
     });
@@ -125,7 +125,7 @@ contract('Parameterizer', (accounts) => {
       // check parameters
       const voteQuorum = await parameterizer.get.call('voteQuorum');
       assert.strictEqual(
-        voteQuorum.toString(10), '51',
+        voteQuorum.toString(10), '50',
         'A proposal whose processBy date passed was able to update the parameterizer',
       );
 
@@ -169,7 +169,7 @@ contract('Parameterizer', (accounts) => {
 
       const voteQuorum = await parameterizer.get.call('voteQuorum');
       assert.strictEqual(
-        voteQuorum.toString(10), '51',
+        voteQuorum.toString(10), '50',
         'A proposal whose processBy date passed was able to update the parameterizer',
       );
     });

--- a/test/parameterizer/propExists.js
+++ b/test/parameterizer/propExists.js
@@ -9,7 +9,7 @@ contract('Parameterizer', (accounts) => {
     let token;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { paramProxy, tokenInstance } = await utils.getProxies();
       parameterizer = paramProxy;
       token = tokenInstance;

--- a/test/parameterizer/proposeReparameterization.js
+++ b/test/parameterizer/proposeReparameterization.js
@@ -17,7 +17,7 @@ contract('Parameterizer', (accounts) => {
     let token;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { paramProxy, tokenInstance } = await utils.getProxies();
       parameterizer = paramProxy;
       token = tokenInstance;

--- a/test/parameterizer/proposeReparameterization.js
+++ b/test/parameterizer/proposeReparameterization.js
@@ -89,6 +89,14 @@ contract('Parameterizer', (accounts) => {
     });
 
     it('should not allow a reparameterization for a proposal that already exists', async () => {
+      const receipt = await utils.as(proposer, parameterizer.proposeReparameterization, 'voteQuorum', '51');
+
+      const propID = utils.getReceiptValue(receipt, 'propID');
+      const paramProposal = await parameterizer.proposals.call(propID);
+
+      assert.strictEqual(paramProposal[6].toString(10), '51', 'The reparameterization proposal ' +
+        'was not created, or not created correctly.');
+
       const applicantStartingBalance = await token.balanceOf.call(secondProposer);
 
       try {

--- a/test/parameterizer/tokenClaims.js
+++ b/test/parameterizer/tokenClaims.js
@@ -14,7 +14,7 @@ contract('Parameterizer', (accounts) => {
     let voting;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, paramProxy, tokenInstance } = await utils.getProxies(token);
       voting = votingProxy;
       parameterizer = paramProxy;

--- a/test/parameterizer/voterReward.js
+++ b/test/parameterizer/voterReward.js
@@ -14,7 +14,7 @@ contract('Parameterizer', (accounts) => {
     let voting;
     let parameterizer;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, paramProxy, tokenInstance } = await utils.getProxies(token);
       voting = votingProxy;
       parameterizer = paramProxy;

--- a/test/registry/Registry.js
+++ b/test/registry/Registry.js
@@ -12,7 +12,7 @@ contract('Registry', (accounts) => {
     let parameterizer;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const {
         votingProxy, paramProxy, registryProxy, tokenInstance,
       } = await utils.getProxies();

--- a/test/registry/appWasMade.js
+++ b/test/registry/appWasMade.js
@@ -18,7 +18,7 @@ contract('Registry', (accounts) => {
     let token;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { registryProxy, tokenInstance } = await utils.getProxies();
       registry = registryProxy;
       token = tokenInstance;

--- a/test/registry/apply.js
+++ b/test/registry/apply.js
@@ -44,6 +44,7 @@ contract('Registry', (accounts) => {
 
     it('should not allow a listing to apply which has a pending application', async () => {
       const listing = utils.getListingHash('nochallenge.net');
+      await utils.as(applicant, registry.apply, listing, paramConfig.minDeposit, '');
 
       // Verify that the application exists.
       const result = await registry.listings.call(listing);
@@ -62,6 +63,7 @@ contract('Registry', (accounts) => {
       'should add a listing to the whitelist which went unchallenged in its application period',
       async () => {
         const listing = utils.getListingHash('nochallenge.net');
+        await utils.as(applicant, registry.apply, listing, paramConfig.minDeposit, '');
         await utils.increaseTime(paramConfig.applyStageLength + 1);
         await registry.updateStatus(listing);
         const result = await registry.isWhitelisted.call(listing);
@@ -71,6 +73,7 @@ contract('Registry', (accounts) => {
 
     it('should not allow a listing to apply which is already listed', async () => {
       const listing = utils.getListingHash('nochallenge.net');
+      await utils.addToWhitelist(listing, paramConfig.minDeposit, applicant, registry);
 
       // Verify that the listing is whitelisted.
       const result = await registry.isWhitelisted.call(listing);

--- a/test/registry/apply.js
+++ b/test/registry/apply.js
@@ -15,7 +15,7 @@ contract('Registry', (accounts) => {
     let parameterizer;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { paramProxy, registryProxy, tokenInstance } = await utils.getProxies();
       parameterizer = paramProxy;
       registry = registryProxy;

--- a/test/registry/challenge.js
+++ b/test/registry/challenge.js
@@ -19,7 +19,7 @@ contract('Registry', (accounts) => {
     let parameterizer;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const {
         votingProxy, paramProxy, registryProxy, tokenInstance,
       } = await utils.getProxies();

--- a/test/registry/claimReward.js
+++ b/test/registry/claimReward.js
@@ -19,7 +19,7 @@ contract('Registry', (accounts) => {
     let voting;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, registryProxy, tokenInstance } = await utils.getProxies();
       voting = votingProxy;
       registry = registryProxy;

--- a/test/registry/claimRewards.js
+++ b/test/registry/claimRewards.js
@@ -19,7 +19,7 @@ contract('Registry', (accounts) => {
     let voting;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, registryProxy, tokenInstance } = await utils.getProxies();
       voting = votingProxy;
       registry = registryProxy;

--- a/test/registry/deposit.js
+++ b/test/registry/deposit.js
@@ -19,7 +19,7 @@ contract('Registry', (accounts) => {
     let token;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { registryProxy, tokenInstance } = await utils.getProxies();
       registry = registryProxy;
       token = tokenInstance;

--- a/test/registry/determineReward.js
+++ b/test/registry/determineReward.js
@@ -14,7 +14,7 @@ contract('Registry', (accounts) => {
     let token;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { registryProxy, tokenInstance } = await utils.getProxies();
       registry = registryProxy;
       token = tokenInstance;

--- a/test/registry/isWhitelisted.js
+++ b/test/registry/isWhitelisted.js
@@ -14,7 +14,7 @@ contract('Registry', (accounts) => {
     let token;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { registryProxy, tokenInstance } = await utils.getProxies();
       registry = registryProxy;
       token = tokenInstance;

--- a/test/registry/tokenClaims.js
+++ b/test/registry/tokenClaims.js
@@ -19,7 +19,7 @@ contract('Registry', (accounts) => {
     let voting;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, registryProxy, tokenInstance } = await utils.getProxies();
       voting = votingProxy;
       registry = registryProxy;

--- a/test/registry/updateStatus.js
+++ b/test/registry/updateStatus.js
@@ -18,7 +18,7 @@ contract('Registry', (accounts) => {
     let token;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { registryProxy, tokenInstance } = await utils.getProxies();
       registry = registryProxy;
       token = tokenInstance;

--- a/test/registry/updateStatuses.js
+++ b/test/registry/updateStatuses.js
@@ -18,7 +18,7 @@ contract('Registry', (accounts) => {
     let token;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { registryProxy, tokenInstance } = await utils.getProxies();
       registry = registryProxy;
       token = tokenInstance;

--- a/test/registry/userStories.js
+++ b/test/registry/userStories.js
@@ -19,7 +19,7 @@ contract('Registry', (accounts) => {
     let voting;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { votingProxy, registryProxy, tokenInstance } = await utils.getProxies();
       voting = votingProxy;
       registry = registryProxy;

--- a/test/registry/withdraw.js
+++ b/test/registry/withdraw.js
@@ -19,7 +19,7 @@ contract('Registry', (accounts) => {
     let token;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const { registryProxy, tokenInstance } = await utils.getProxies();
       registry = registryProxy;
       token = tokenInstance;

--- a/test/utils.js
+++ b/test/utils.js
@@ -72,15 +72,15 @@ const utils = {
 
   approveProxies: async (accounts, token, plcr, parameterizer, registry) => (
     Promise.all(accounts.map(async (user) => {
-      await token.transfer(user, 10000000000);
+      await token.transfer(user, 10000000000000000000000000);
       if (plcr) {
-        await token.approve(plcr.address, 10000000000, { from: user });
+        await token.approve(plcr.address, 10000000000000000000000000, { from: user });
       }
       if (parameterizer) {
-        await token.approve(parameterizer.address, 10000000000, { from: user });
+        await token.approve(parameterizer.address, 10000000000000000000000000, { from: user });
       }
       if (registry) {
-        await token.approve(registry.address, 10000000000, { from: user });
+        await token.approve(registry.address, 10000000000000000000000000, { from: user });
       }
     }))
   ),

--- a/test/voting.js
+++ b/test/voting.js
@@ -17,7 +17,7 @@ contract('PLCRVoting', (accounts) => {
     let parameterizer;
     let registry;
 
-    before(async () => {
+    beforeEach(async () => {
       const {
         votingProxy, paramProxy, registryProxy, tokenInstance,
       } = await utils.getProxies();


### PR DESCRIPTION
Currently tests are stateful which leads to problems when trying to change tests. A stateless design (using `beforeEach()`) allows tests to be independent and easy to modify. Using `beforeEach()` instead of `before()` allows each test case to have its own proxy contracts, thus eliminating statefulness. 

* Change all `before()` to `beforeEach()`
* Edit a few dependent test functions to have less state

Also, the current values of `minDeposit` and `pMinDeposit` in config.json does not represent realistic token holdings (1 tok = 1e18).

* Change values of `minDeposit` and `pMinDeposit` to 1e19 and 1e20 respectively
* Increase token holdings of user accounts in utils.js
* Refactor tests in challengeReparameterization.js to use new deposit values

The test suite now has less state and is more indicative of real world token values.